### PR TITLE
Remove text about ss3sim for the path #66

### DIFF
--- a/User_Guides/getting_started/Getting_Started_SS.Rmd
+++ b/User_Guides/getting_started/Getting_Started_SS.Rmd
@@ -253,8 +253,6 @@ If you have never used the command line before, it will be helpful to learn a fe
 
 # Appendix 2: Putting SS in your PATH {#app2}
 
-This appendix is a slightly modified version of the ss3sim vignette section "Putting SS3 in your path." The original version can be found in the [ss3sim repository](https://github.com/ss3sim/ss3sim/blob/master/vignettes/introduction.Rmd).
-
 Instead of copying the SS executable to each model folder, SS can be put in your system path, which is a list of folders that your operating system looks in whenever you type the name of a program on the command line. This approach saves on storage space since the SS binary (i.e., the SS executable or exe) is about 2.2 MB and having it located in each folder can be prohibitive in a large-scale simulation testing study. Even if you are not running a large simulation study, putting SS in your path may still be convenient, as you can use the same executable on many models, there is no need to specify a full file path to the executable each time you run a model, and no need to create a batch file that refers to the executable's location.
 
 ## For Unix (OS X and Linux)


### PR DESCRIPTION
Remove the text about ss3sim in the path because the ss3sim will reference this information here soon.